### PR TITLE
Fix for CryoSPARC container /tmp collisions

### DIFF
--- a/form.yml
+++ b/form.yml
@@ -21,7 +21,6 @@ form:
   - CRYOSPARC_MASTER_PATH
   - CRYOSPARC_WORKER_PATH
   - SINGULARITY_OPTIONS
-  - SINGULARITY_MOUNTS
   - desktop
   - bc_vnc_idle
   - bc_vnc_resolution
@@ -68,9 +67,7 @@ attributes:
     value: /sdf/group/cryoem/sw/images/cryosparc/#SINGULARITY_IMAGE_TAG/cryosparc-desktop@#SINGULARITY_IMAGE_TAG.sif
   SINGULARITY_OPTIONS:
     #widget: "hidden_field"
-    value: "-B $CRYOSPARC_DATADIR/config.sh:$CRYOSPARC_MASTER_PATH/config.sh,$CRYOSPARC_DATADIR/run:$CRYOSPARC_MASTER_PATH/run,$CRYOSPARC_DATADIR/config.sh:$CRYOSPARC_WORKER_PATH/config.sh"
-  SINGULARITY_MOUNTS:
-    value: "${SINGULARITY_MOUNTS} --no-mount tmp -B ${LSCRATCH}/tmp:tmp"
+    value: "--no-mount tmp -B ${LSCRATCH}/tmp:tmp -B $CRYOSPARC_DATADIR/config.sh:$CRYOSPARC_MASTER_PATH/config.sh,$CRYOSPARC_DATADIR/run:$CRYOSPARC_MASTER_PATH/run,$CRYOSPARC_DATADIR/config.sh:$CRYOSPARC_WORKER_PATH/config.sh"
   SINGULARITY_IMAGE_TAG:
     widget: select
     label: "CryoSPARC Version"

--- a/form.yml
+++ b/form.yml
@@ -65,9 +65,11 @@ attributes:
   SINGULARITY_IMAGE:
     widget: "hidden_field"
     value: /sdf/group/cryoem/sw/images/cryosparc/#SINGULARITY_IMAGE_TAG/cryosparc-desktop@#SINGULARITY_IMAGE_TAG.sif
+  LSCRATCH_TMP:
+    widget: "hidden_field"
+    value: "${LSCRATCH}/tmp"
   SINGULARITY_OPTIONS:
-    #widget: "hidden_field"
-    value: "--no-mount tmp -B ${LSCRATCH}/tmp:tmp -B $CRYOSPARC_DATADIR/config.sh:$CRYOSPARC_MASTER_PATH/config.sh,$CRYOSPARC_DATADIR/run:$CRYOSPARC_MASTER_PATH/run,$CRYOSPARC_DATADIR/config.sh:$CRYOSPARC_WORKER_PATH/config.sh"
+    value: "--no-mount tmp -B ${LSCRATCH}:/tmp,$CRYOSPARC_DATADIR/config.sh:$CRYOSPARC_MASTER_PATH/config.sh,$CRYOSPARC_DATADIR/run:$CRYOSPARC_MASTER_PATH/run,$CRYOSPARC_DATADIR/config.sh:$CRYOSPARC_WORKER_PATH/config.sh"
   SINGULARITY_IMAGE_TAG:
     widget: select
     label: "CryoSPARC Version"

--- a/form.yml
+++ b/form.yml
@@ -21,6 +21,7 @@ form:
   - CRYOSPARC_MASTER_PATH
   - CRYOSPARC_WORKER_PATH
   - SINGULARITY_OPTIONS
+  - SINGULARITY_MOUNTS
   - desktop
   - bc_vnc_idle
   - bc_vnc_resolution
@@ -67,12 +68,15 @@ attributes:
     value: /sdf/group/cryoem/sw/images/cryosparc/#SINGULARITY_IMAGE_TAG/cryosparc-desktop@#SINGULARITY_IMAGE_TAG.sif
   SINGULARITY_OPTIONS:
     #widget: "hidden_field"
-    value: "--no-mount tmp -B $CRYOSPARC_DATADIR/config.sh:$CRYOSPARC_MASTER_PATH/config.sh,$CRYOSPARC_DATADIR/run:$CRYOSPARC_MASTER_PATH/run,$CRYOSPARC_DATADIR/config.sh:$CRYOSPARC_WORKER_PATH/config.sh"
+    value: "-B $CRYOSPARC_DATADIR/config.sh:$CRYOSPARC_MASTER_PATH/config.sh,$CRYOSPARC_DATADIR/run:$CRYOSPARC_MASTER_PATH/run,$CRYOSPARC_DATADIR/config.sh:$CRYOSPARC_WORKER_PATH/config.sh"
+  SINGULARITY_MOUNTS:
+    value: "${SINGULARITY_MOUNTS} --no-mount tmp -B ${LSCRATCH}/tmp:tmp"
   SINGULARITY_IMAGE_TAG:
     widget: select
     label: "CryoSPARC Version"
     options:
       - [ "4.5.3", "4.5.3-0" ]
+      - [ "4.6.2", "4.6.2-0" ]
   CRYOSPARC_LOCAL_WORKER:
     widget: "hidden_field"
     value: "1"
@@ -121,6 +125,6 @@ attributes:
     label: Show advanced settings...
   CRYOSPARC_LICENSE_ID:
     required: true
-    label: "Cryosparc License ID"
+    label: "CryoSPARC License ID"
     help: |
       Enter a valid CryoSPARC license ID. You can obtain a new license at https://cryosparc.com/download


### PR DESCRIPTION
Creates a separate /tmp bind-mount per user instead of having multiple users sharing host /tmp, causing start-up issues for XFCE desktop when VNC is connecting to session.